### PR TITLE
Salt State Conversion - Best Practices Applied

### DIFF
--- a/conversion_report.json
+++ b/conversion_report.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "2025-11-06T17:15:54.224872",
+  "repository": "ironman627/saltsamples",
+  "branch": "saltsamples_salt_conversion_20251106_171554",
+  "target_directory": ".",
+  "results": {
+    "converted": 5,
+    "skipped": 5,
+    "test_skipped": 2,
+    "errors": 0
+  },
+  "workflow_run_id": "19143901537",
+  "commit_sha": "c266d05c145bfc6f234ffad188fca093ab5ccd61"
+}

--- a/gittest/mixed_format_test.sls
+++ b/gittest/mixed_format_test.sls
@@ -1,8 +1,9 @@
 # Test file showing difference between old format and proper Salt states
 
 # This is OLD FORMAT (will be converted) - file path as state ID
-/etc/myapp/config.conf:
+etc_myapp_config_conf:
   file.managed:
+    - name: /etc/myapp/config.conf
     - source: salt://myapp/config.conf
 
 # This is PROPER FORMAT (will NOT be converted) - proper state ID with module
@@ -16,6 +17,7 @@ configure_nginx:
     - source: salt://nginx/nginx.conf
 
 # Another OLD FORMAT (will be converted) - Windows path as state ID  
-C:\Windows\System32\config.ini:
+Windows_System32_config_ini:
   file.managed:
+    - name: C:\Windows\System32\config.ini
     - source: salt://windows/config.ini

--- a/gittest/mixed_format_test.sls.backup
+++ b/gittest/mixed_format_test.sls.backup
@@ -1,0 +1,21 @@
+# Test file showing difference between old format and proper Salt states
+
+# This is OLD FORMAT (will be converted) - file path as state ID
+/etc/myapp/config.conf:
+  file.managed:
+    - source: salt://myapp/config.conf
+
+# This is PROPER FORMAT (will NOT be converted) - proper state ID with module
+install_nginx:
+  pkg.installed:
+    - name: nginx
+
+configure_nginx:
+  file.managed:
+    - name: /etc/nginx/nginx.conf
+    - source: salt://nginx/nginx.conf
+
+# Another OLD FORMAT (will be converted) - Windows path as state ID  
+C:\Windows\System32\config.ini:
+  file.managed:
+    - source: salt://windows/config.ini

--- a/gittest/multi_file_old.sls
+++ b/gittest/multi_file_old.sls
@@ -1,12 +1,14 @@
 # File.managed shift to best practice format
 # /srv/salt/test/best
 
-/srv/salt/test/best/old.sls:
+srv_salt_test_best_old_sls:
   file.absent:
+    - name: /srv/salt/test/best/old.sls
 
 
-/srv/salt/test/best/old.sls:
+srv_salt_test_best_old_sls_2:
   file.managed:
+    - name: /srv/salt/test/best/old.sls
     - source: salt://test/best/old_format.sls
     - template: jinja
 

--- a/gittest/multi_file_old.sls.backup
+++ b/gittest/multi_file_old.sls.backup
@@ -1,0 +1,12 @@
+# File.managed shift to best practice format
+# /srv/salt/test/best
+
+/srv/salt/test/best/old.sls:
+  file.absent:
+
+
+/srv/salt/test/best/old.sls:
+  file.managed:
+    - source: salt://test/best/old_format.sls
+    - template: jinja
+

--- a/salt_state_converter.py
+++ b/salt_state_converter.py
@@ -1,0 +1,1 @@
+404: Not Found

--- a/use-cases/mixed_format_test.sls
+++ b/use-cases/mixed_format_test.sls
@@ -1,8 +1,9 @@
 # Test file showing difference between old format and proper Salt states
 
 # This is OLD FORMAT (will be converted) - file path as state ID
-/etc/myapp/config.conf:
+etc_myapp_config_conf:
   file.managed:
+    - name: /etc/myapp/config.conf
     - source: salt://myapp/config.conf
 
 # This is PROPER FORMAT (will NOT be converted) - proper state ID with module
@@ -16,6 +17,7 @@ configure_nginx:
     - source: salt://nginx/nginx.conf
 
 # Another OLD FORMAT (will be converted) - Windows path as state ID  
-C:\Windows\System32\config.ini:
+Windows_System32_config_ini:
   file.managed:
+    - name: C:\Windows\System32\config.ini
     - source: salt://windows/config.ini

--- a/use-cases/mixed_format_test.sls.backup
+++ b/use-cases/mixed_format_test.sls.backup
@@ -1,0 +1,21 @@
+# Test file showing difference between old format and proper Salt states
+
+# This is OLD FORMAT (will be converted) - file path as state ID
+/etc/myapp/config.conf:
+  file.managed:
+    - source: salt://myapp/config.conf
+
+# This is PROPER FORMAT (will NOT be converted) - proper state ID with module
+install_nginx:
+  pkg.installed:
+    - name: nginx
+
+configure_nginx:
+  file.managed:
+    - name: /etc/nginx/nginx.conf
+    - source: salt://nginx/nginx.conf
+
+# Another OLD FORMAT (will be converted) - Windows path as state ID  
+C:\Windows\System32\config.ini:
+  file.managed:
+    - source: salt://windows/config.ini

--- a/use-cases/multi_file_old.sls
+++ b/use-cases/multi_file_old.sls
@@ -1,12 +1,14 @@
 # File.managed shift to best practice format
 # /srv/salt/test/best
 
-/srv/salt/test/best/old.sls:
+srv_salt_test_best_old_sls:
   file.absent:
+    - name: /srv/salt/test/best/old.sls
 
 
-/srv/salt/test/best/old.sls:
+srv_salt_test_best_old_sls_2:
   file.managed:
+    - name: /srv/salt/test/best/old.sls
     - source: salt://test/best/old_format.sls
     - template: jinja
 

--- a/use-cases/multi_file_old.sls.backup
+++ b/use-cases/multi_file_old.sls.backup
@@ -1,0 +1,12 @@
+# File.managed shift to best practice format
+# /srv/salt/test/best
+
+/srv/salt/test/best/old.sls:
+  file.absent:
+
+
+/srv/salt/test/best/old.sls:
+  file.managed:
+    - source: salt://test/best/old_format.sls
+    - template: jinja
+

--- a/use-cases/old_format.sls
+++ b/use-cases/old_format.sls
@@ -1,8 +1,9 @@
 # File.managed shift to best practice format
 # /srv/salt/test/best
 
-/srv/salt/test/best/old.sls:
+srv_salt_test_best_old_sls:
   file.managed:
+    - name: /srv/salt/test/best/old.sls
     - source: salt://test/best/old_format.sls
     - template: jinja
 

--- a/use-cases/old_format.sls.backup
+++ b/use-cases/old_format.sls.backup
@@ -1,0 +1,8 @@
+# File.managed shift to best practice format
+# /srv/salt/test/best
+
+/srv/salt/test/best/old.sls:
+  file.managed:
+    - source: salt://test/best/old_format.sls
+    - template: jinja
+


### PR DESCRIPTION
Converted 5 Salt state files to use best practices:
- Unique state IDs instead of file paths
- Explicit 'name' parameters for all states
- Proper YAML structure and indentation

Files processed: $(git diff --cached --name-only | wc -l)
Files converted: 5
Files skipped: 5
Test files skipped: 2

Generated by Salt State Converter GitHub Action
Workflow: Salt State Converter
Run ID: 19143901537
Commit: c266d05c145bfc6f234ffad188fca093ab5ccd61